### PR TITLE
add GrantFlow as open-source alternative to GrantHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Curating the best open-source alternatives for famous apps.
 - [cPanel](#cpanel)
 - [Facebook](#facebook)
 - [Github](#github)
+- [GrantHub](#granthub)
 - [Google Analytics](#google-analytics)
 - [Google Docs](#google-docs)
 - [Google Drive](#google-drive)
@@ -86,6 +87,11 @@ Curating the best open-source alternatives for famous apps.
 - [Gitea](https://github.com/go-gitea)
 - [OneDev](https://github.com/theonedev)
 - [Pagure](https://github.com/Pagure)
+
+### [GrantHub](https://www.granthub.com/)
+> Note: GrantHub is shutting down. These open-source alternatives can replace it.
+- [GrantFlow](https://github.com/WabiSabikk/grantflow) — Full grant lifecycle manager: Kanban pipeline, deadline tracking, 146K+ grant discovery, funder CRM, budget management, CSV migration from GrantHub. ([Demo](https://grantflow-zeta.vercel.app))
+
 
 ### [Google Analytics](https://analytics.google.com/)
 - [Matomo](https://github.com/Matomo-org)


### PR DESCRIPTION
## What

Adding [GrantFlow](https://github.com/WabiSabikk/grantflow) as an open-source alternative to **GrantHub**, which is shutting down and leaving 400,000+ small nonprofits without a grant management tool.

## GrantFlow details

- **GitHub:** https://github.com/WabiSabikk/grantflow
- **Live demo:** https://grantflow-zeta.vercel.app (demo@grantflow.app / demo1234)
- **License:** MIT
- **Self-hostable:** Yes (Next.js + PostgreSQL)

## What it replaces

GrantHub was the leading grant management SaaS for small nonprofits. It is shutting down, and GrantFlow is a free, open-source replacement with:
- Kanban grant pipeline
- Deadline tracking & email reminders  
- Grant discovery (146K+ opportunities via Grants.gov + ProPublica)
- Funder CRM
- Budget tracking (restricted funds)
- CSV import — including direct GrantHub data migration
- Document library

## Why this fits the list

GrantHub is a proprietary SaaS (like Asana, Trello, Salesforce in your list). GrantFlow is the open-source, self-hostable, free alternative — exactly the pattern this list curates.