### PR TITLE
Add Quizlet section with Anki and Revu

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Curating the best open-source alternatives for famous apps.
 - [Instagram](#instagram)
 - [Npm](#npm)
 - [Netlify](#netlify)
+- [Quizlet](#quizlet)
 - [Salesforce](#salesforce)
 - [Segment](#segment)
 - [Shopify](#shopify)
@@ -135,6 +136,10 @@ Curating the best open-source alternatives for famous apps.
 
 ### [Postman](https://www.postman.com/)
 - [Postwoman](https://github.com/liyasthomas/postwoman)
+
+### [Quizlet](https://quizlet.com/)
+- [Anki](https://github.com/ankitects/anki)
+- [Revu](https://github.com/JuliusBrussee/revu-swift)
 
 ### [Salesforce](https://salesforce.com/)
 - [Odoo](https://github.com/odoo)


### PR DESCRIPTION
## Summary

- Adds a new **Quizlet** section to the list
- Includes [Anki](https://github.com/ankitects/anki) — the well-known open-source spaced repetition app
- Includes [Revu](https://github.com/JuliusBrussee/revu-swift) — a local-first spaced repetition app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, study guides, exams, and forecasting ([revu.cards](https://revu.cards), GPL-3.0)

Quizlet is one of the most popular commercial flashcard/study platforms and there was no section for it yet. Both Anki and Revu are actively maintained open-source alternatives.