### PR TITLE
Add Customermates as HubSpot/Salesforce alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Curating the best open-source alternatives for famous apps.
 - [Tsuru](https://github.com/tsuru)
 
 ### [Hubspot](https://www.hubspot.com/)
+- [Customermates](https://github.com/customermates/customermates)
 - [Erxes](https://github.com/erxes)
 
 ### [Intercom](https://intercom.com)
@@ -137,6 +138,7 @@ Curating the best open-source alternatives for famous apps.
 - [Postwoman](https://github.com/liyasthomas/postwoman)
 
 ### [Salesforce](https://salesforce.com/)
+- [Customermates](https://github.com/customermates/customermates)
 - [Odoo](https://github.com/odoo)
 - [SuiteCRM](https://github.com/salesagility/SuiteCRM)
 - [Crust CRM](https://github.com/crusttech)


### PR DESCRIPTION
Adding [Customermates](https://github.com/customermates/customermates) — an open-source CRM (AGPL-3.0) with native n8n workflow automation, built for small B2B teams. Self-hostable via Docker.

- **Website:** https://customermates.com
- **License:** AGPL-3.0
- **Stack:** TypeScript (Next.js, NestJS, PostgreSQL)

Added under both the HubSpot and Salesforce sections as an open-source alternative.