### PR TITLE
Add Cursor section with LocoPilot as open-source alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Curating the best open-source alternatives for famous apps.
 - [Bombora / 6sense](#bombora--6sense)
 - [Canny](#canny)
 - [cPanel](#cpanel)
+- [Cursor](#cursor)
 - [Facebook](#facebook)
 - [Github](#github)
 - [GrantHub](#granthub)
@@ -78,6 +79,9 @@ Curating the best open-source alternatives for famous apps.
 - [Vesta](https://github.com/serghey-rodin/vesta)
 - [Webmin](https://github.com/webmin)
 - [Hestia](https://github.com/hestiacp)
+
+### [Cursor](https://www.cursor.com/)
+- [LocoPilot](https://github.com/bobfromarcher/LocoPilot) — Vision, browser, and desktop control for any local LLM. 35 endpoints, zero cloud, fully local via Ollama. MIT license.
 
 ### [Disqus](https://disqus.com/)
 - [Isso](https://github.com/posativ/isso)


### PR DESCRIPTION
## Summary

Adds a [Cursor](https://www.cursor.com/) section with [LocoPilot](https://github.com/bobfromarcher/LocoPilot) as an open-source alternative.

Cursor is a popular commercial AI-powered coding/automation tool. LocoPilot provides comparable AI automation capabilities - vision, browser, and desktop control for any local LLM - as a fully open-source, MIT-licensed alternative that runs entirely on localhost via Ollama with zero cloud dependencies. 35 REST endpoints in a single-file FastAPI server.

Added to both the Apps TOC (alphabetically between cPanel and Facebook) and the section content (between cPanel and Disqus).