### PR TITLE
Add Beton Inspector (open-source 6sense / Clearbit alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Curating the best open-source alternatives for famous apps.
 
 ### [Bombora](https://bombora.com/) / [6sense](https://6sense.com/)
 - [Signals CLI](https://github.com/sortlist/signals-cli)
+- [Beton Inspector](https://github.com/getbeton/inspector)
 
 ### [Canny](https://canny.io/)
 - [Fider](https://github.com/getfider)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Curating the best open-source alternatives for famous apps.
 - [Apollo.io / Outreach](#apolloio--outreach)
 - [Bombora / 6sense](#bombora--6sense)
 - [Canny](#canny)
+- [Common Room / Pocus](#common-room--pocus)
 - [cPanel](#cpanel)
 - [Facebook](#facebook)
 - [Github](#github)
@@ -69,11 +70,13 @@ Curating the best open-source alternatives for famous apps.
 
 ### [Bombora](https://bombora.com/) / [6sense](https://6sense.com/)
 - [Signals CLI](https://github.com/sortlist/signals-cli)
-- [Beton Inspector](https://github.com/getbeton/inspector)
 
 ### [Canny](https://canny.io/)
 - [Fider](https://github.com/getfider)
 - [Astuto](https://github.com/riggraz/astuto)
+
+### [Common Room](https://www.commonroom.io/) / [Pocus](https://www.pocus.com/)
+- [Beton Inspector](https://github.com/getbeton/inspector)
 
 ### [cPanel](https://cpanel.net/)
 - [Vesta](https://github.com/serghey-rodin/vesta)


### PR DESCRIPTION
Adds [Beton Inspector](https://github.com/getbeton/inspector) under a new **Common Room / Pocus** section (open-source alternatives to those PLG signal platforms).

Beton Inspector is open-source (AGPL-3.0) revenue intelligence: it detects buying signals from PostHog product-usage data + CRM, scores accounts, and routes the warmest leads to sales reps. Self-hostable via Docker.