### PR TITLE
Add Wispr Flow open-source alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Curating the best open-source alternatives for famous apps.
 - [TeamViewer](#teamviewer)
 - [Trello](#trello)
 - [Typeform](#typeform)
+- [Wispr Flow](#wispr-flow)
 - [Youtube](#youtube)
 - [Zapier](#zapier)
 - [Zendesk](#zendesk)
@@ -203,6 +204,13 @@ Curating the best open-source alternatives for famous apps.
 ### [Typeform](https://typeform.com)
 - [OhMyForm](https://github.com/ohmyform)
 - [Super Easy Forms](https://github.com/gkpty/super-easy-forms)
+
+### [Wispr Flow](https://wisprflow.ai/)
+- [VoiceInk](https://github.com/Beingpax/VoiceInk)
+- [OpenWhispr](https://github.com/OpenWhispr/openwhispr)
+- [FreeFlow](https://github.com/zachlatta/freeflow)
+- [VoiceTypr](https://github.com/moinulmoin/voicetypr)
+- [Blurt](https://github.com/alexkroman/blurt)
 
 ### [Youtube](https://youtube.com)
 - [Peertube](https://github.com/Chocobozzz/PeerTube)


### PR DESCRIPTION
Adds a **Wispr Flow** section (AI dictation / voice-typing) — a popular proprietary app with a healthy open-source field but no entry here yet. Listed alternatives (all OSS, GitHub-hosted, actively maintained):

- [VoiceInk](https://github.com/Beingpax/VoiceInk) — on-device, Swift (~5.4k★)
- [OpenWhispr](https://github.com/OpenWhispr/openwhispr) — cross-platform, local + BYO-cloud (~4k★)
- [FreeFlow](https://github.com/zachlatta/freeflow) — free Mac alternative inspired by Wispr Flow (~2k★)
- [VoiceTypr](https://github.com/moinulmoin/voicetypr) — offline, Mac/Windows
- [Blurt](https://github.com/alexkroman/blurt) — native macOS, AssemblyAI cloud STT

Added to the alphabetical TOC as well (between Typeform and Youtube). Disclosure: I maintain Blurt — included as one of several genuine alternatives, not the sole entry.