### PR TITLE
Add CloudConvert section with VidKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Curating the best open-source alternatives for famous apps.
 - [Apollo.io / Outreach](#apolloio--outreach)
 - [Bombora / 6sense](#bombora--6sense)
 - [Canny](#canny)
+- [CloudConvert](#cloudconvert)
 - [cPanel](#cpanel)
 - [Facebook](#facebook)
 - [Github](#github)
@@ -73,6 +74,9 @@ Curating the best open-source alternatives for famous apps.
 ### [Canny](https://canny.io/)
 - [Fider](https://github.com/getfider)
 - [Astuto](https://github.com/riggraz/astuto)
+
+### [CloudConvert](https://cloudconvert.com/)
+- [VidKit](https://github.com/TondaRuzicka/vidkit)
 
 ### [cPanel](https://cpanel.net/)
 - [Vesta](https://github.com/serghey-rodin/vesta)


### PR DESCRIPTION
Adds a CloudConvert section with VidKit — an open-source (MIT), fully
browser-based video compressor & converter (MP4/MOV/MKV/WebM/MP3/GIF).
All processing runs client-side with no upload, making it a
privacy-respecting alternative to CloudConvert and similar
upload-based converters.

Disclosure: I'm the author/maintainer of VidKit.