### PR TITLE
Add Knocket as Intercom alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Curating the best open-source alternatives for famous apps.
 ### [Intercom](https://intercom.com)
 - [chatwoot](https://github.com/chatwoot)
 - [chaskiq](https://github.com/chaskiq)
+- [Knocket](https://trtc.io/solutions/knocket) — Free-forever live chat widget + contact page + unified inbox
 
 ### [Instagram](https://instagram.com)
 - [Pixelfed](https://github.com/pixelfed)


### PR DESCRIPTION
Adds Knocket under the Intercom section. Knocket is a free-forever live chat widget + contact page + unified inbox. More info: https://trtc.io/solutions/knocket