### PR TITLE
Add Yap as an open source Wispr Flow alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Curating the best open-source alternatives for famous apps.
 - [OhMyForm](https://github.com/ohmyform)
 - [Super Easy Forms](https://github.com/gkpty/super-easy-forms)
 
+### [Wispr Flow](https://wisprflow.ai/)
+- [Yap](https://github.com/FrigadeHQ/yap)
+
 ### [Youtube](https://youtube.com)
 - [Peertube](https://github.com/Chocobozzz/PeerTube)
 - [NodeTube](https://github.com/mayeaux/nodetube)


### PR DESCRIPTION
Adds Yap under a new Wispr Flow entry.

Yap is an open source menu bar app for on-device voice dictation on macOS. You set a hotkey, talk, and the text is pasted into whatever field you were typing in. Like Wispr Flow it is hotkey dictation that types into any app, but it runs entirely on-device with no model to download and no network code. MIT licensed.

https://github.com/FrigadeHQ/yap