### PR TITLE
Add OpenShorts as an Opus Clip alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Curating the best open-source alternatives for famous apps.
 - [Instagram](#instagram)
 - [Npm](#npm)
 - [Netlify](#netlify)
+- [Opus Clip](#opus-clip)
 - [Quizlet](#quizlet)
 - [Salesforce](#salesforce)
 - [Segment](#segment)
@@ -149,6 +150,9 @@ Curating the best open-source alternatives for famous apps.
 
 ### [Netlify](https://netlify.com)
 - [StaticDeploy](https://github.com/staticdeploy)
+
+### [Opus Clip](https://www.opus.pro/)
+- [OpenShorts](https://github.com/mutonby/openshorts)
 
 ### [Postman](https://www.postman.com/)
 - [Postwoman](https://github.com/liyasthomas/postwoman)


### PR DESCRIPTION
Adds a new **Opus Clip** section with its open-source alternative, plus the matching entry in the `## Apps` index (kept in place alphabetically, between Netlify and Postman).

```md
### [Opus Clip](https://www.opus.pro/)
- [OpenShorts](https://github.com/mutonby/openshorts)
```

[Opus Clip](https://www.opus.pro/) is the leading proprietary AI clipping tool (turn a long video into short vertical clips). [OpenShorts](https://github.com/mutonby/openshorts) is a genuine functional replacement: AI moment detection, face-tracking 9:16 reframe, animated subtitles, dubbing and direct publishing.

- License: MIT
- Language: Python, runs via Docker Compose (self-hostable, no watermark, no limits)
- Traction: 2.9k+ stars, 800+ forks, actively maintained
- Site: https://www.openshorts.app/

Format matches the neighbouring entries (plain repo links, no descriptions).