### PR TITLE
Add Otter.ai section (open-source transcription alternatives)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Curating the best open-source alternatives for famous apps.
 - [Instagram](#instagram)
 - [Npm](#npm)
 - [Netlify](#netlify)
+- [Otter.ai](#otterai)
 - [Quizlet](#quizlet)
 - [Salesforce](#salesforce)
 - [Segment](#segment)
@@ -149,6 +150,12 @@ Curating the best open-source alternatives for famous apps.
 
 ### [Netlify](https://netlify.com)
 - [StaticDeploy](https://github.com/staticdeploy)
+
+### [Otter.ai](https://otter.ai/)
+- [Buzz](https://github.com/chidiwilliams/buzz)
+- [Meetily](https://github.com/Zackriya-Solutions/meetily)
+- [Vibe](https://github.com/thewh1teagle/vibe)
+- [YazSes](https://github.com/MSKazemi/yazses)
 
 ### [Postman](https://www.postman.com/)
 - [Postwoman](https://github.com/liyasthomas/postwoman)


### PR DESCRIPTION
Adds **Otter.ai** to the app list. It is one of the more commonly-searched-for proprietary tools with no entry here yet, and the open-source side of the category is genuinely strong now.

Four alternatives, all active and all doing on-device transcription rather than reselling a cloud API:

- **[Buzz](https://github.com/chidiwilliams/buzz)** — offline transcription and translation, cross-platform (~20.9k ★)
- **[Meetily](https://github.com/Zackriya-Solutions/meetily)** — privacy-first AI meeting assistant (~28.9k ★)
- **[Vibe](https://github.com/thewh1teagle/vibe)** — desktop transcription app (~7.1k ★)
- **[YazSes](https://github.com/MSKazemi/yazses)** — offline hold-to-talk dictation plus speaker-labelled meeting capture

**Disclosure:** I maintain YazSes, the last and by far the smallest of the four. I added the section because the category was missing rather than to place my own project in it — the other three stand on their own and would belong here whether or not mine did. If you would prefer the section without YazSes, that is completely fine and I will still consider the addition worthwhile.

Placed the section between Netlify and Postman, and added the index entry after Netlify to match.