### PR TITLE
Add Persona as Evernote alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Curating the best open-source alternatives for famous apps.
 ### [Evernote](https://evernote.com/)
 - [Paperwork](https://github.com/paperwork)
 - [OpenNote](https://github.com/FoxUSA/OpenNote)
+- [Persona](https://github.com/jayamitkatariya/personacli)
 
 ### [Facebook](https://facebook.com)
 - [Mastodon](https://github.com/tootsuite/mastodon)


### PR DESCRIPTION
Persona is a local-first open-source Evernote alternative: notes, tasks and AI chat. Plain markdown files, no accounts, no cloud. MIT.

Repo: https://github.com/jayamitkatariya/personacli