### PR TITLE
Add n8n Uptime Ping Alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,3 +228,4 @@ Curating the best open-source alternatives for famous apps.
 ### [Zoom](https://zoom.com)
 - [Jitsi](https://github.com/jitsi)
 - [TaleForge](https://www.tale-forge.com) - Free creative writing platform with book, manga/webtoon, and screenplay editors. PWA with offline support. ([Source Code](https://github.com/SamDreamsMaker/TaleForge))
+- [n8n Uptime Ping Alert](https://github.com/DeusAcc/n8n-uptime-ping-alert) - Free n8n workflow that checks a site every 5 minutes and alerts on Telegram only on state change.


### PR DESCRIPTION
Adding a free, open-source n8n workflow (n8n Uptime Ping Alert) that fits this list.

The repo README documents usage and also links to a paid bundle at https://negozio.mooo.com/?src=diegoleme-awesome-open-source-alternatives — the specific workflow linked here is itself free (no account/paywall).

Happy to adjust placement/wording if it doesn't fit.