### PR TITLE
Add Tabox

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Curating the best open-source alternatives for famous apps.
 - [OhMyForm](https://github.com/ohmyform)
 - [Super Easy Forms](https://github.com/gkpty/super-easy-forms)
 
+### [Workona](https://workona.com/) / [Toby](https://www.gettoby.com/)
+- [Tabox](https://github.com/gilgold/tabox)
+
 ### [Youtube](https://youtube.com)
 - [Peertube](https://github.com/Chocobozzz/PeerTube)
 - [NodeTube](https://github.com/mayeaux/nodetube)


### PR DESCRIPTION
Adds [Tabox](https://chromewebstore.google.com/detail/tabox-save-and-share-tab/bdbliblipiempfdkkkjohnecmeknnpoa) — a free, open-source browser extension (https://github.com/gilgold/tabox) that saves all open tabs and tab groups into named collections and reopens the exact session (windows, groups, colors, order) in one click. Google Drive sync across devices, share-via-link, AI-powered tab organization. 4.4★ on the Chrome Web Store; works on Chrome, Edge and Firefox.

Disclosure: I'm the developer of Tabox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)