### PR TITLE
Add Fivetran section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Curating the best open-source alternatives for famous apps.
 - [Canny](#canny)
 - [cPanel](#cpanel)
 - [Facebook](#facebook)
+- [Fivetran](#fivetran)
 - [Github](#github)
 - [GrantHub](#granthub)
 - [Google Analytics](#google-analytics)
@@ -90,6 +91,13 @@ Curating the best open-source alternatives for famous apps.
 - [Mastodon](https://github.com/tootsuite/mastodon)
 - [Okuna](https://github.com/OkunaOrg)
 - [Convo](https://github.com/hiconvo)
+
+### [Fivetran](https://www.fivetran.com/)
+- [Airbyte](https://github.com/airbytehq/airbyte)
+- [Meltano](https://github.com/meltano/meltano)
+- [dlt](https://github.com/dlt-hub/dlt)
+- [ingestr](https://github.com/bruin-data/ingestr)
+- [Bruin](https://github.com/bruin-data/bruin)
 
 ### [Github](https://github.com/)
 - [Gogs](https://github.com/gogs)


### PR DESCRIPTION
Adds a **Fivetran** section. Fivetran is a widely used proprietary managed data-integration (ELT) service, and the list has no data-pipeline category yet.

Open-source alternatives listed:
- [Airbyte](https://github.com/airbytehq/airbyte) — ELT platform with 300+ connectors.
- [Meltano](https://github.com/meltano/meltano) — CLI-first ELT built on the Singer spec.
- [dlt](https://github.com/dlt-hub/dlt) — Python library for loading data with schema inference.
- [ingestr](https://github.com/bruin-data/ingestr) — CLI that copies data between databases and SaaS sources with one command.
- [Bruin](https://github.com/bruin-data/bruin) — CLI combining ingestion, SQL/Python transformations, and data quality checks.

Formatting follows the existing convention: section title links to the proprietary product, alternatives as a plain bullet list of repository links, section placed alphabetically between Facebook and Github, with a matching entry added to the Apps table of contents.

Disclosure: I work on Bruin (ingestr is from the same team). The other three are included because a Fivetran section would be incomplete without them.