### PR TITLE
Add DocSend alternative: HTMLRadar

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Curating the best open-source alternatives for famous apps.
 ### [Disqus](https://disqus.com/)
 - [Isso](https://github.com/posativ/isso)
 
+### [DocSend](https://www.docsend.com/)
+- [HTMLRadar](https://github.com/htmlradar/htmlradar) - Open-source DocSend alternative: turn any HTML file into a tracked share link with per-section read analytics. ([Demo](https://htmlradar.com))
+
 ### [Evernote](https://evernote.com/)
 - [Paperwork](https://github.com/paperwork)
 - [OpenNote](https://github.com/FoxUSA/OpenNote)


### PR DESCRIPTION
HTMLRadar is an open-source (AGPL-3.0) DocSend alternative: it turns any HTML file into a tracked share link with per-section read analytics, showing who opened it and what they read.

https://github.com/diegoleme/awesome-open-source-alternatives