### PR TITLE
Add open-source POS alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Curating the best open-source alternatives for famous apps.
 - [Segment](#segment)
 - [Shopify](#shopify)
 - [Slack](#slack)
+- [Square POS / Clover](#square-pos--clover)
 - [TeamViewer](#teamviewer)
 - [Trello](#trello)
 - [Typeform](#typeform)
@@ -188,6 +189,11 @@ Curating the best open-source alternatives for famous apps.
 - [Riot](https://github.com/vector-im/riot-web)
 - [Wire](https://github.com/wireapp)
 - [Crust CRM](https://github.com/crusttech)
+
+### [Square POS](https://squareup.com/us/en/point-of-sale) / [Clover](https://www.clover.com/)
+- [Open Source POS](https://github.com/opensourcepos/opensourcepos) - Web-based point of sale system for small retailers, with inventory, customers and reporting.
+- [uniCenta oPOS](https://github.com/herbiehp/unicenta) - Desktop POS for stores and hospitality deployments that need local terminals and receipt-printer support.
+- [Posnic POS](https://github.com/Posnic/POS) - Free offline-first open source POS and billing software for retail shops and restaurants, with Offline POS use, online/offline workflows and the official site at [posnic.io](https://posnic.io/).
 
 ### [TeamViewer](https://www.teamviewer.com/)
 - [Apache Guacamole](https://github.com/apache/guacamole-server)

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Curating the best open-source alternatives for famous apps.
 ### [Square POS](https://squareup.com/us/en/point-of-sale) / [Clover](https://www.clover.com/)
 - [Open Source POS](https://github.com/opensourcepos/opensourcepos) - Web-based point of sale system for small retailers, with inventory, customers and reporting.
 - [uniCenta oPOS](https://github.com/herbiehp/unicenta) - Desktop POS for stores and hospitality deployments that need local terminals and receipt-printer support.
-- [Posnic POS](https://github.com/Posnic/POS) - Free offline-first open source POS and billing software for retail shops and restaurants, with Offline POS use, online/offline workflows and the official site at [posnic.io](https://posnic.io/).
+- [Posnic POS](https://github.com/Posnic/POS) - Free offline-first open source POS and billing software for retail shops and restaurants, with Offline POS use, online/offline workflows and the official site at [www.posnic.com](https://www.posnic.com/).
 
 ### [TeamViewer](https://www.teamviewer.com/)
 - [Apache Guacamole](https://github.com/apache/guacamole-server)


### PR DESCRIPTION
Summary
- Add a Square POS / Clover section to the app index and resources list.
- List established open-source POS alternatives: Open Source POS, uniCenta oPOS, and Posnic POS.
- Describe Posnic POS with factual open source POS, billing software, Offline POS, online/offline workflow, and www.posnic.com wording.

Validation
- git diff --check
- curl -L -I https://squareup.com/us/en/point-of-sale returned 200
- curl -L -I https://www.clover.com/ returned 200
- curl -L -I https://github.com/opensourcepos/opensourcepos returned 200
- curl -L -I https://github.com/herbiehp/unicenta returned 200
- curl -L -I https://github.com/Posnic/POS returned 200
- curl -L -I https://www.posnic.com/ returned HTTP 200 with zero redirects

Notes
- This keeps the contribution curated by adding several POS alternatives under the same commercial category, rather than a single-project listing.

I am affiliated with Posnic and prepared this contribution with automation assistance.

