### PR TITLE
Add Jasper / Surfer SEO section with AltoRank

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Curating the best open-source alternatives for famous apps.
 - [Hubspot](#hubspot)
 - [Intercom](#intercom)
 - [Instagram](#instagram)
+- [Jasper](#jasper--surfer-seo) / [Surfer SEO](#jasper--surfer-seo)
 - [Npm](#npm)
 - [Netlify](#netlify)
 - [Quizlet](#quizlet)
@@ -141,6 +142,9 @@ Curating the best open-source alternatives for famous apps.
 
 ### [Instagram](https://instagram.com)
 - [Pixelfed](https://github.com/pixelfed)
+
+### [Jasper](https://www.jasper.ai/) / [Surfer SEO](https://surferseo.com/)
+- [AltoRank](https://github.com/AltoRank/altorank)
 
 ### [Npm](https://www.npmjs.com)
 - [Verdaccio](https://github.com/verdaccio)


### PR DESCRIPTION
Adds a new section for **Jasper / Surfer SEO** with [AltoRank](https://github.com/AltoRank/altorank) as the open-source alternative, following the existing pattern of pairing two comparable SaaS products under one heading (like Apollo.io / Outreach).

AI SEO content tooling is a category the list does not cover yet, and it is one where the commercial options are all closed-source subscriptions.

AltoRank is AGPL-3.0 and the whole product is in the repo — keyword research, domain audit, article generation with scoring and fact-checking, rank tracking, and publishing to 13 destinations across 10 CMS platforms. Self-hostable with `docker/compose.yml` against your own Supabase.

Index entry added alphabetically between Instagram and Npm, matching the existing ordering.

Disclosure: I am the author. It is pre-launch with a first tagged release (v0.1.0) and the README says so; happy to close this if you would rather the list only carried more established projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)